### PR TITLE
Cannot use ctx.throw

### DIFF
--- a/src/KoaAdapter.ts
+++ b/src/KoaAdapter.ts
@@ -327,6 +327,6 @@ export class KoaAdapter extends AbstractHttpAdapter<
   }
 
   public isHeadersSent(response: Koa.Response): any {
-    return response.headerSent
+    return response?.headerSent
   }
 }

--- a/src/KoaReply.ts
+++ b/src/KoaReply.ts
@@ -11,9 +11,15 @@ function getOverwrites(
   response: Koa.Response,
   statusCode?: number,
 ): ResponseOverwrites {
+  if (response) {
+    return {
+      status: response.status,
+      headers: Object.entries(response.headers) as [string, string][],
+    }
+  };
   return {
-    status: response.status,
-    headers: Object.entries(response.headers) as [string, string][],
+    status: statusCode || 200,
+    headers: [],
   };
 }
 
@@ -38,6 +44,10 @@ export const koaReply = (
   body: any,
   statusCode?: number,
 ): void => {
+  if (!response) {
+    return;
+  }
+
   const overwrites = getOverwrites(response, statusCode);
 
   response.ctx.respond = false;


### PR DESCRIPTION
When I'm trying to use ctx.throw in legacy Koa code this methods caused errors. Reason is: there is no response object when we are throwing exception.

I rewrite code little bit to support this situation as well.

Please review.