### PR TITLE
Add support for NestJS 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ await app.init();
 
 [Versioning feature](https://docs.nestjs.com/techniques/versioning#versioning) is not yet supported.
 
+[Search http method](https://github.com/nestjs/nest/pull/10533) is not yet supported by koa-router.
+
 Nest components which operates with Koa response like exception filters needs to use the `koaReply` utility function from
 this package because the implementation if the reply in adapter doesn't allow to use standard way of setting
 `body` and `status` properties.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nest-koa-adapter",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nest-koa-adapter",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "koa": "2.15.0",
@@ -15,9 +15,9 @@
       },
       "devDependencies": {
         "@koa/cors": "5.0.0",
-        "@nestjs/common": "9.4.3",
-        "@nestjs/core": "9.4.3",
-        "@nestjs/testing": "9.4.3",
+        "@nestjs/common": "10.4.7",
+        "@nestjs/core": "10.4.7",
+        "@nestjs/testing": "10.4.7",
         "@types/koa": "2.15.0",
         "@types/koa__cors": "3.3.1",
         "@types/koa-bodyparser": "4.3.12",
@@ -50,8 +50,8 @@
         "koa-views": "8.0.0"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9",
-        "@nestjs/core": "^9"
+        "@nestjs/common": "^10",
+        "@nestjs/core": "^10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -485,13 +485,14 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.4.3.tgz",
-      "integrity": "sha512-Gd6D4IaYj01o14Bwv81ukidn4w3bPHCblMUq+SmUmWLyosK+XQmInCS09SbDDZyL8jy86PngtBLTdhJ2bXSUig==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.7.tgz",
+      "integrity": "sha512-gIOpjD3Mx8gfYGxYm/RHPcJzqdknNNFCyY+AxzBT3gc5Xvvik1Dn5OxaMGw5EbVfhZgJKVP0n83giUOAlZQe7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.5.3",
+        "tslib": "2.7.0",
         "uid": "2.0.2"
       },
       "funding": {
@@ -499,16 +500,12 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "cache-manager": "<=5",
         "class-transformer": "*",
         "class-validator": "*",
-        "reflect-metadata": "^0.1.12",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
         "rxjs": "^7.1.0"
       },
       "peerDependenciesMeta": {
-        "cache-manager": {
-          "optional": true
-        },
         "class-transformer": {
           "optional": true
         },
@@ -518,17 +515,18 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.4.3.tgz",
-      "integrity": "sha512-Qi63+wi55Jh4sDyaj5Hhx2jOpKqT386aeo+VOKsxnd+Ql9VvkO/FjmuwBGUyzkJt29ENYc+P0Sx/k5LtstNpPQ==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.7.tgz",
+      "integrity": "sha512-AIpQzW/vGGqSLkKvll1R7uaSNv99AxZI2EFyVJPNGDgFsfXaohfV1Ukl6f+s75Km+6Fj/7aNl80EqzNWQCS8Ig==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "3.2.0",
-        "tslib": "2.5.3",
+        "path-to-regexp": "3.3.0",
+        "tslib": "2.7.0",
         "uid": "2.0.2"
       },
       "funding": {
@@ -536,11 +534,11 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/websockets": "^9.0.0",
-        "reflect-metadata": "^0.1.12",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
         "rxjs": "^7.1.0"
       },
       "peerDependenciesMeta": {
@@ -556,22 +554,23 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.4.3.tgz",
-      "integrity": "sha512-LDT8Ai2eKnTzvnPaJwWOK03qTaFap5uHHsJCv6dL0uKWk6hyF9jms8DjyVaGsaujCaXDG8izl1mDEER0OmxaZA==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.7.tgz",
+      "integrity": "sha512-aS3sQ0v4g8cyHDzW3xJv1+8MiFAkxUNXmnau588IFFI/nBIo/kevLNHNPr85keYekkJ/lwNDW72h8UGg8BYd9w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tslib": "2.5.3"
+        "tslib": "2.7.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/core": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0"
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/microservices": {
@@ -6484,10 +6483,11 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7702,10 +7702,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-      "dev": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-koa-adapter",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Koa HTTP adapter for Nest.js",
   "main": "dist/index.js",
   "files": [
@@ -31,8 +31,8 @@
     "koa-router": "12.0.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9",
-    "@nestjs/core": "^9"
+    "@nestjs/common": "^10",
+    "@nestjs/core": "^10"
   },
   "optionalDependencies": {
     "@koa/cors": "5.0.0",
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@koa/cors": "5.0.0",
-    "@nestjs/common": "9.4.3",
-    "@nestjs/core": "9.4.3",
-    "@nestjs/testing": "9.4.3",
+    "@nestjs/common": "10.4.7",
+    "@nestjs/core": "10.4.7",
+    "@nestjs/testing": "10.4.7",
     "@types/koa": "2.15.0",
     "@types/koa-bodyparser": "4.3.12",
     "@types/koa-router": "7.4.8",

--- a/src/KoaAdapter.ts
+++ b/src/KoaAdapter.ts
@@ -301,6 +301,9 @@ export class KoaAdapter extends AbstractHttpAdapter<
         [RequestMethod.PATCH]: router.patch,
         [RequestMethod.POST]: router.post,
         [RequestMethod.PUT]: router.put,
+        [RequestMethod.SEARCH]: (...args: any[]) => {
+          throw new Error('SEARCH method not yet supported in koa-router');
+        },
       };
 
       const routeMethod = (
@@ -333,5 +336,13 @@ export class KoaAdapter extends AbstractHttpAdapter<
 
   public isHeadersSent(response: Koa.Response): any {
     return response.headerSent;
+  }
+
+  public appendHeader(response: Koa.Response, name: string, value: string): void {
+    response.append(name, value);
+  }
+
+  public getHeader(response: Koa.Response, name: string): string {
+    return response.get(name);
   }
 }


### PR DESCRIPTION
In NestJS 10, `AbstractHttpAdapter` requires support for the following:

1. `RequestMethod.SEARCH` in `createMiddlewareFactory`

> Since koa-router does not support the SEARCH HTTP method, I implemented a placeholder function that throws an error.

2. Methods `appendHeader` and `getHeader`